### PR TITLE
Move from Knox to aws-sdk for S3 interfacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Once you have the provider, you can pass it as a parameter to `createFSCollectio
 ```js
 const MyFilesS3Collection = createFSCollection({
   collectionName: 'MyFilesS3',
+  uploadTo3rdParty: s3StorageProvider.upload,
+  deleteFrom3rdParty: s3StorageProvider.delete,
   storageProvider: s3StorageProvider,
 })
 ```

--- a/lib/server/createS3StorageProvider.js
+++ b/lib/server/createS3StorageProvider.js
@@ -1,5 +1,4 @@
-import knox from 'knox';
-
+import S3 from 'aws-sdk/clients/s3';
 import curryUploadToS3 from './curryUploadToS3';
 import curryDeleteFromS3 from './curryDeleteFromS3';
 import serveFilesFromS3 from './serveFilesFromS3';
@@ -9,19 +8,25 @@ import serveFilesFromS3 from './serveFilesFromS3';
  *
  * @param {{key: String, secret: String, region: String, bucket: String}} config
  * @param {String} cfdomain
- * @return {{bucket: Object, upload: curriedUploadToS3, delete: curriedDeleteFromS3, serve: serveFilesFromS3}}
+ * @return {{S3Client: Object, upload: curriedUploadToS3, delete: curriedDeleteFromS3, serve: serveFilesFromS3}}
  */
 export default function createS3StorageProvider(config, cfdomain) {
-  // Fix CloudFront certificate issue Read:
-  // https://github.com/chilts/awssum/issues/164
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
-
-  const bucket = knox.createClient(config);
+  const S3Client = new S3({
+    secretAccessKey: config.secret,
+    accessKeyId: config.key,
+    region: config.region,
+    bucket: config.bucket,
+    // sslEnabled: true, // optional
+    httpOptions: {
+      timeout: 6000,
+      agent: false
+    }
+  });
 
   return {
-    bucket,
-    upload: curryUploadToS3(bucket, cfdomain),
-    delete: curryDeleteFromS3(bucket),
+    S3Client,
+    upload: curryUploadToS3(S3Client, undefined, config.region, config.bucket),
+    delete: curryDeleteFromS3(S3Client, config.region, config.bucket),
     serve: serveFilesFromS3,
   };
 }

--- a/lib/server/curryDeleteFromS3.js
+++ b/lib/server/curryDeleteFromS3.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import has from 'lodash/has';
 
 let bound;
 
@@ -14,7 +14,7 @@ if (Meteor.isServer) {
  *
  * @return {function} returns curriedDeleteFromS3
  */
-export default function curryDeleteFromS3(S3Client) {
+export default function curryDeleteFromS3(S3Client, bucket) {
   /**
    * curriedDeleteFromS3 - Deletes a file from S3 and updates the doc's versions
    * that contains that file.
@@ -31,8 +31,9 @@ export default function curryDeleteFromS3(S3Client) {
    */
   return function curriedDeleteFromS3(FilesCollection, docId, versionReference) {
     return new Promise((resolve, reject) => {
-      if (_.has(versionReference, 'meta.pipePath')) {
-        S3Client.deleteFile(versionReference.meta.pipePath, (deleteFromS3Error) => {
+      if (has(versionReference, 'meta.pipePath')) {
+        // using aws-sdk but never really tested that since I can't fire a delete from the FScollection
+        S3Client.deleteObject({Key: versionReference.meta.pipePath, Bucket: bucket}, (deleteFromS3Error) => {
           bound(() => {
             if (deleteFromS3Error) {
               reject(deleteFromS3Error);
@@ -45,8 +46,8 @@ export default function curryDeleteFromS3(S3Client) {
                 }
                 // TODO remove console.log and add it to a log collection
                 console.log(
-                `${versionReference.name ||
-                `${docId}-${versionReference.version}`}: deleted from S3`
+                    `${versionReference.name ||
+                    `${docId}-${versionReference.version}`}: deleted from S3`
                 );
                 resolve(versionReference);
               });

--- a/lib/server/curryUploadToS3.js
+++ b/lib/server/curryUploadToS3.js
@@ -1,13 +1,12 @@
 import snakeCase from 'lodash/snakeCase';
 import { Meteor } from 'meteor/meteor';
 import { Random } from 'meteor/random';
-
+import fs from 'fs';
 let bound;
 
 if (Meteor.isServer) {
-  bound = Meteor.bindEnvironment(callback => (callback()));
+  bound = Meteor.bindEnvironment(callback => callback());
 }
-
 
 /**
  * curryUploadToS3 - it curries the curriedUploadToS3 with an S3Client and a
@@ -18,8 +17,7 @@ if (Meteor.isServer) {
  *
  * @return {function} returns curriedUploadToS3
  */
-export default function curryUploadToS3(S3Client, cfdomain) {
-
+export default function curryUploadToS3(S3Client, cfdomain, region, bucket) {
   /**
    * curriedUploadToS3 - Uploads a file to S3 and updates the collection with
    * the new metadata. It also unlinks the original file from the internal FS.
@@ -33,42 +31,58 @@ export default function curryUploadToS3(S3Client, cfdomain) {
    * @return {promise} returns a promise - resolve: returns the same versionRef
    * as the input - reject: returns the error that cause it
    */
+  console.log('cfdomain', cfdomain)
+  console.log('region', region)
+  console.log('bucket', bucket)
   return function curriedUploadToS3(FilesCollection, docId, versionRef) {
     return new Promise((resolve, reject) => {
       const { version } = versionRef;
+      const url = cfdomain ? cfdomain : `https://s3.${region}.amazonaws.com/${bucket}`
+      // const url = cfdomain ? cfdomain : `https://s3.${region}.amazonaws.com/${bucket}`
+      // console.log(versionRef);
       // We use Random.id() instead of real file's _id to secure files from reverse
       // engineering as after viewing this code it will be easy to get access to
       // unlisted and protected files
-      const filePath = `${snakeCase(FilesCollection.collectionName)}/${version}/${(Random.id())}-${version}.${versionRef.extension}`;
+      const filePath = `${snakeCase(FilesCollection.collectionName)}/${version}/${Random.id()}-${version}.${versionRef.extension}`;
+      const fileStream = fs.createReadStream(versionRef.path);
+      fileStream.on('error', function(err) {
+        console.log('File Error', err);
+      });
+
       // Here we upoload the file
-      S3Client.putFile(versionRef.path, filePath, (S3error, res) => {
+      S3Client.putObject({Bucket: bucket, Key: filePath, Body: fileStream, ContentType: versionRef.type }, (S3error, res) => {
         bound(() => {
           if (S3error) {
+            console.log('error', S3error);
+
             reject(S3error); // Reject
           } else {
             // If no error, update the mongo document
             const upd = {
               $set: {
                 [`versions.${version}.uploadedTo3rdParty`]: true,
-                [`versions.${version}.meta.pipeFrom`]: `${cfdomain}/${filePath}`,
+                [`versions.${version}.meta.pipeFrom`]: `${url}/${filePath}`,
                 [`versions.${version}.meta.pipePath`]: filePath,
               },
             };
             // Here we perform the document update
-            FilesCollection.collection.update({
-              _id: docId,
-            }, upd, (collectionError) => {
-              if (collectionError) {
-                reject(collectionError);
-              } else {
-                // Unlink original files from FS after successful upload to AWS:S3
-                FilesCollection.unlink(FilesCollection.collection.findOne(docId), version);
-                // TODO remove console.log and add it to a log collection
-                console.log(`${versionRef.name || `${docId}-${version}`}: uploaded`);
-                res.resume(); // Recommended in Knox docs.
-                resolve(versionRef);
-              }
-            });
+            FilesCollection.collection.update(
+                {
+                  _id: docId,
+                },
+                upd,
+                collectionError => {
+                  if (collectionError) {
+                    reject(collectionError);
+                  } else {
+                    // Unlink original files from FS after successful upload to AWS:S3
+                    FilesCollection.unlink(FilesCollection.collection.findOne(docId), version);
+                    // TODO remove console.log and add it to a log collection
+                    console.log(`${versionRef.name || `${docId}-${version}`}: uploaded`);
+                    resolve(versionRef);
+                  }
+                }
+            );
           }
         });
       });


### PR DESCRIPTION
I took the new provider code using aws-sdk from @Apollinaire It is fully functional on 1.11.0 of Vulcan version but in the latest version (1.12.0 and 1.13.0) it's not working.

The problem is that the collection to save the image isn't created and save the preview of the image on the imageId field. See the image

![image](https://user-images.githubusercontent.com/8105777/55366354-9b19b100-54a5-11e9-82a1-f8e212c004f8.png)

Anyone have a suggestion about what I could try to fix the PR to work with the latest version
 